### PR TITLE
修复re.match函数调用第二个参数为None时的异常

### DIFF
--- a/botoy/decorators/_in_content.py
+++ b/botoy/decorators/_in_content.py
@@ -27,6 +27,8 @@ def in_content(string: str, raw: bool = True):
                     content = pic_ctx.Content
                 else:
                     content = ctx.Content
+                if content is None:
+                    content = ''
                 if re.match(string, content):
                     return func(ctx)
             return None


### PR DESCRIPTION
if re.match(string, content):
       │  │     │       └ None
       │  │     └ 'ocr'
       │  └ <function match at 0x000001190BCD1310>
       └ <module 're' from 'C:\\Python39\\lib\\re.py'>

TypeError: expected string or bytes-like object